### PR TITLE
init commit optimistic relay

### DIFF
--- a/datastore/utils.go
+++ b/datastore/utils.go
@@ -1,9 +1,11 @@
 package datastore
 
-func MakeBlockBuilderStatus(isHighPrio, isBlacklisted bool) BlockBuilderStatus {
-	if isBlacklisted {
+func MakeBlockBuilderStatus(s BlockBuilderStatus) BlockBuilderStatusStr {
+	if s.Blacklisted {
 		return RedisBlockBuilderStatusBlacklisted
-	} else if isHighPrio {
+	} else if s.Optimistic {
+		return RedisBlockBuilderStatusOptimistic
+	} else if s.HighPrio {
 		return RedisBlockBuilderStatusHighPrio
 	} else {
 		return RedisBlockBuilderStatusLowPrio

--- a/services/housekeeper/housekeeper.go
+++ b/services/housekeeper/housekeeper.go
@@ -338,7 +338,10 @@ func (hk *Housekeeper) updateBlockBuildersInRedis() {
 
 	hk.log.Infof("updating %d block builders in Redis...", len(builders))
 	for _, builder := range builders {
-		status := datastore.MakeBlockBuilderStatus(builder.IsHighPrio, builder.IsBlacklisted)
+		status := datastore.MakeBlockBuilderStatus(datastore.BlockBuilderStatus{
+			HighPrio:    builder.IsHighPrio,
+			Blacklisted: builder.IsBlacklisted,
+		})
 		hk.log.Infof("updating block builder in Redis: %s - %s", builder.BuilderPubkey, status)
 		err = hk.redis.SetBlockBuilderStatus(builder.BuilderPubkey, status)
 		if err != nil {


### PR DESCRIPTION
there are a few potential paths we could take to set up an optimistic relay. below are two that i considered:

Option 1. Leave the builder status as is (`HighPrio`, `LowPrio`, `Blacklisted`). Modify the relay logic to only run block simulation for `LowPrio` builders, thus redefining `HighPrio` as optimistic. Thus when we call the `prio-load-balancer` (https://github.com/flashbots/prio-load-balancer) we only ever use the `LowPrio` queue. 
*Pros* 
- No modification of redis KV store or postgres db schema. 
- Smallest amount of code change.
*Cons*
- Reduces our flexibility. We no longer can differentiate between `LowPrio` and `HighPrio` builders who are in the pessimistic mode.
Option 2. Add a new builder status called `Optimisitic`. Thus we effectively have 4 builder statuses: `Optimistic > HighPrio > LowPrio > Blacklisted`.
*Pros*
- More flexibility as it allows us to maintain the distinction between different priorities on the pessimistic builders.
- Doesn't conflate `HighPrio`, which has a different semantic meaning in https://github.com/flashbots/prio-load-balancer with `Optimisitic`, which is a new concept we introduce.
*Cons* 
- More code.
- Requires schema and redis updates.
- Cognitive load to explain new hierarchy of builder statuses.

<ins>Based on the above, I propose Option 2 for its flexiblity.</ins>

initial plan for changes required to implement Option 2:

1. add a new builder state called `Optimistic`. 
2. modify the `handleSubmitNewBlock` Builder API handler to skip the block simulation for blocks from builders who are in `Optimistic` state. these blocks will be pushed into an `OptimisticBlock` buffered channel where their validity will be checked asynchronously. If any of them turn out to be invalid, we will demote that block builder to `LowPrio` status (or could even blacklist them if we want to be conservative).
3. modify the `handleGetHeader` Proposer API handler to check for best bid block (could do this in-band or through a similar buffered channel mechanism as we do for all incoming blocks). if it turns out that the winning bid was an invalid block for one of our proposers (and they ended up publishing it), we need to reimburse them using the collateral posted by the builder of the invalid block (still need to flesh this out a bit). 

open questions:
1. how do we ensure that we only accept optimistic blocks if the previous slot block has been validated? 